### PR TITLE
Adds expansive and format options to CLI

### DIFF
--- a/git-prlog
+++ b/git-prlog
@@ -5,12 +5,23 @@
 #     - #38: Fix titles - Rico S.
 #     - #24: Fix signatures - John A.
 
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -e|--expansive) expansive=1;;
-    *) git_params="${git_params} ${1}";
-  esac; shift
+for i in "$@"; do
+  case $i in
+    -f=*|--format=*)
+      format="${i#*=}"
+      shift
+      ;;
+    -e|--expansive)
+      expansive=1
+      shift
+      ;;
+    *)
+      git_params="${git_params} ${1}"
+      shift
+      ;;
+  esac
 done
+
 # trim leading whitespace
 git_params="$(echo -e "${git_params}" | sed -e 's/^[[:space:]]*//')"
 

--- a/git-prlog
+++ b/git-prlog
@@ -5,7 +5,21 @@
 #     - #38: Fix titles - Rico S.
 #     - #24: Fix signatures - John A.
 
-commits=$(git log "$@" --oneline | grep "Merge pull request" | awk '{print $1}')
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -e|--expansive) expansive=1;;
+    *) git_params="${git_params} ${1}";
+  esac; shift
+done
+# trim leading whitespace
+git_params="$(echo -e "${git_params}" | sed -e 's/^[[:space:]]*//')"
+
+if [[ $expansive ]]; then
+  commits=$(git log "$git_params" --oneline --first-parent | awk '{print $1}');
+else
+  commits=$(git log "$git_params" --oneline --first-parent | grep "Merge pull request" | awk '{print $1}');
+fi
+
 if [ -z "$format" ]; then format='md'; fi
 if [ "$format" == 'md' ]; then
   format='- %b (%P)'
@@ -25,6 +39,8 @@ for commit in $commits; do
   author_name=$(git show $mergesource --pretty="%an" | head -n 1)
   date=$(git show $mergesource --pretty="%ct" | head -n 1)
   date=$(date -r "$date" +%Y/%m/%d)
+
+  if ! [[ $pr = \#* ]]; then pr="$commit"; fi
 
   echo $format \
     | sed "s~%dd~${date}~g" \


### PR DESCRIPTION
Sometimes we have devs modifying the PR commit message + description when merging a PR (weird, I know), so those commits don't get taken in by this script.

Added in the `-e` / `--expansive` option to force the script not to discriminate against PR commits that don't start with `Merge pull request`.

Doesn't seem to be a way to gather the PR number on these modified commits though, so `--expansive` pops in a short commit ID instead (which github also automatically links).

Lastly, the `--format` option hooks onto the existing format mechanism in the script, so something like `--format=tsv` will do as you expect.

---

Given the following raw dump:

```
$ git log A..B --oneline

a3e3463f (HEAD -> release/1.3, origin/release/1.3) Merge pull request #1502 from hpegdpmsp-telstra/fix/linting-issues/1.3.7
92e79d5e (fix/linting-issues/1.3.7) Fixes linting issues for v1.3.7
d81be146 (fix/rename-suggestion) Merge branch 'release/1.3' of github.houston.entsvcs.net:hpegdpmsp-telstra/career-architecture-framework into release/1.3
46c59844 Merge pull request #1500 from hpegdpmsp-telstra/defect/issue-791
6f3113bc (origin/defect/issue-791, defect/issue-791) Updates implementation for window object
1422ff42 Merge pull request #1499 from hpegdpmsp-telstra/defect/job-recommendation
4e7433e9 (origin/defect/job-recommendation, defect/job-recommendation) Correctly implements display flex in ie
ea963b20 Fixes an error in data projection while calculating transferable skills
7f3df95c Implements new links in footer
7d2ab7ee Updates 'envar' to 'envvar'
b20d8d01 Merge branch 'release/1.3' of github.houston.entsvcs.net:hpegdpmsp-telstra/career-architecture-framework into release/1.3
ef0860b8 Removes unnecesasry display flex in job recommendation
12210b8c (origin/fix/transferable-skills-algorithm, fix/transferable-skills-algorithm) Housekeeping
d7a515e6 Corrects typo in leadership skill data projection
342d411e Adjusts projection of data chain in role-comparison component
462bc597 Sets CacheControl and Pragma values to no-cache for the default http headers
41cc6938 (origin/bugfix/menu-navigation) Sets CacheControl and Pragma values to no-cache for the default http headers
43d14270 Adds new links in webpack config files
20007289 Fixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component
d483039d Fixes routing in the footer links
5635a485 Fixes routing to my search, my team, and my profile
89e15281 Fixes routing to my search, my team, and my profile
```

### `git prlog A..B`
```
- Fixes linting issues for v1.3.7 (#1502)
- Implements all footer links (#1500)
- Fixes text overlap in job recommendation using IE (#1499)
```

### `git prlog A..B --expansive`
```
- Fixes linting issues for v1.3.7 (#1502)
- Implements all footer links (#1500)
- Fixes text overlap in job recommendation using IE (#1499)
- Fixes an error in data projection while calculating transferable skills (ea963b20)
- Sets CacheControl and Pragma values to no-cache for the default http headers (462bc597)
- Fixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component (20007289)
- Fixes routing to my search, my team, and my profile (5635a485)
```

### `git prlog A..B --expansive --format=mda`
```
- #1502 Fixes linting issues for v1.3.7 - *Author Name*
- #1500 Implements all footer links - *Author Name*
- #1499 Fixes text overlap in job recommendation using IE - *Author Name*
- ea963b20 Fixes an error in data projection while calculating transferable skills - *Author Name*
- 462bc597 Sets CacheControl and Pragma values to no-cache for the default http headers - *Author Name*
- 20007289 Fixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component - *Author Name*
- 5635a485 Fixes routing to my search, my team, and my profile - *Author name*
```

### `git prlog A..B --expansive --format=tsv`
```
\t#1502\tFixes linting issues for v1.3.7\tAuthor Name
\t#1500\tImplements all footer links\tAuthor Name
\t#1499\tFixes text overlap in job recommendation using IE\tAuthor Name
\tea963b20\tFixes an error in data projection while calculating transferable skills\tAuthor Name
\t462bc597\tSets CacheControl and Pragma values to no-cache for the default http headers\tAuthor Name
\t20007289\tFixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component\tAuthor Name
\t5635a485\tFixes routing to my search, my team, and my profile\tAuthor Name
```

### `git prlog A..B --expansive --format=raw`
```
Merge pull request #1502 from hpegdpmsp-telstra/fix/linting-issues/1.3.7\tFixes linting issues for v1.3.7
Merge pull request #1500 from hpegdpmsp-telstra/defect/issue-791\tImplements all footer links
Merge pull request #1499 from hpegdpmsp-telstra/defect/job-recommendation\tFixes text overlap in job recommendation using IE
Fixes an error in data projection while calculating transferable skills\tFixes an error in data projection while calculating transferable skills
Sets CacheControl and Pragma values to no-cache for the default http headers\tSets CacheControl and Pragma values to no-cache for the default http headers
Fixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component\tFixes routing in the footer links and Fixes routing to profile when clicking the name in jumbotron.component
Fixes routing to my search, my team, and my profile\tFixes routing to my search, my team, and my profile
```